### PR TITLE
Bug fixes from code review (archive month, set_option_list, dead code)

### DIFF
--- a/web-server/RASPtable-old.js
+++ b/web-server/RASPtable-old.js
@@ -72,8 +72,8 @@ function padwithzero(string) {
 
 function setSize() {
     var titleBox = document.getElementById("topTitle");
-    var zoomBox = document.getElementById("zoomBox");;
-    var scaleBox = document.getElementById("botScale");;
+    var zoomBox = document.getElementById("zoomBox");
+    var scaleBox = document.getElementById("botScale");
     var height = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
     var width = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
     titleBox.style.height   =  "68px";

--- a/web-server/RASPtable-old.js
+++ b/web-server/RASPtable-old.js
@@ -738,9 +738,9 @@ function getSplitTime() {
 	var day = getSelectedValue("daypicker")
 	var hour = getSelectedValue("hourpicker")
 	var D = new Date()
-	D.setFullYear(year, month, day)
+	D.setFullYear(year, month-1, day)
 	D.setHours(hour/100 - offset/60)
-	var splittime = [D.getFullYear() + "-" + padwithzero(D.getMonth()) + "-" + padwithzero(D.getDate()), padwithzero(D.getHours()) + "00"];
+	var splittime = [D.getFullYear() + "-" + padwithzero(D.getMonth()+1) + "-" + padwithzero(D.getDate()), padwithzero(D.getHours()) + "00"];
 	// console.log(splittime)
 	return splittime
     } else {

--- a/web-server/RASPtable.js
+++ b/web-server/RASPtable.js
@@ -305,8 +305,8 @@ function set_checkbox_to(checkbox, string_state) {
 }
 
 function set_option_list(options, string_state) {
-    for(j = 0; j < options.length; j++){
-	if(options[j].value == prams[1]){
+    for(var j = 0; j < options.length; j++){
+	if(options[j].value == string_state){
 	    options[j].selected = true;
 	    break;
 	}

--- a/web-server/windgrams/windgram.js
+++ b/web-server/windgrams/windgram.js
@@ -146,7 +146,6 @@ function updateRegion(){
       locationselector.options[j++] = new Option(locations[i][1],i)
     }
   }
-  locationselector.index = 0;
   locationselector.options[0].selected=true;
   showWindgram(false);
 }


### PR DESCRIPTION
## Summary
Four small, isolated fixes uncovered while reviewing the front-end code. Each is in its own commit so they can be reverted independently.

| Commit | Fix |
|---|---|
| `9696373` | Archive-mode month off-by-one in `RASPtable-old.js` |
| `82e75eb` | `set_option_list` now uses its parameter instead of reading global `prams` |
| `89ae60a` | Remove dead `locationselector.index = 0` in `windgram.js` |
| `12a5773` | Strip double-semicolons in `setSize` |

### 1. Archive month off-by-one (`RASPtable-old.js`)
`setFullYear()` and `getMonth()` are 0-indexed, but the picker `<option>` values are 1-indexed (`"01"`–`"12"`). The mismatch was masked for most inputs because the integer flowed through unchanged, but combinations that triggered month/year rollover (e.g. picking Dec 1 23:00 with -8 TZ offset) resolved to URLs like `2025-00-02_0700` and the server returned no data. Same fix already exists in `RASPtable.js` (lines 764, 766).

### 2. `set_option_list` parameter
The function declared a `string_state` parameter but the body read the global `prams` set by `initIt`'s URL parser. Currently works only because every caller assigns `prams` immediately before calling. Made the function honest, no behavior change at current call sites. Also scoped the loop counter `j`.

### 3. Dead `locationselector.index = 0`
`<select>` has no `index` property. The line set a junk JS property on the DOM node and did nothing. The line beneath does the actual selection reset.

### 4. Double-semicolons in `setSize`
Pure typo cleanup, behavior unchanged.

## Findings I deliberately left out
The review surfaced several other things I chose not to touch in this PR — either because the bug is unreachable (Cache LRU on existing-key path), the fix would change rendering (invalid CSS in `RASPtable-old.html`), or the original intent isn't clear enough to be confident (e.g. `paramListFull[1-3]` duplicate value strings). Happy to do follow-up PRs if useful.

## Test plan
- [ ] `RASPtable.html` loads, map renders, parameter dropdown still picks default
- [ ] `RASPtable-old.html` archive mode picks correct date for end-of-month + TZ offset edge cases
- [ ] `windgrams/old.html` region change still re-populates the location dropdown and selects the first entry
- [ ] URL params (`?param=…,opacity=…,…`) still apply on page load