### PR TITLE
Fix hrdps_west tile slicing (disk blowout) and map-png upload path

### DIFF
--- a/continental-test/model-parameters.lisp
+++ b/continental-test/model-parameters.lisp
@@ -98,3 +98,32 @@
     (values (format nil "~A:~A:~A:~A" latq (+ *xstep* latq) lonq (+ *ystep* lonq))
 	(list latq lonq (+ *xstep* latq) (+ *ystep* lonq)))))
 
+;; Geographic corners (lon . lat) of the rotated 1km-west grid, in order, from
+;; un-rotating the GRIB2 grid (confirmed against wgrib2 -grid / gdalwarp). The data
+;; footprint is a tilted quad, NOT the axis-aligned XMIN..XMAX/YMIN..YMAX box: its
+;; corners stick out past the data. A tile box landing entirely outside this quad has
+;; zero grid points, and wgrib2 -small_grib then returns the FULL grid (~200MB), which
+;; is what filled the disk.
+(defparameter *hrdps-west-footprint*
+  '((-126.254d0 . 45.933d0)    ; SW
+    (-109.533d0 . 50.067d0)    ; SE
+    (-114.450d0 . 60.295d0)    ; NE
+    (-134.630d0 . 55.117d0)))  ; NW
+
+(defun point-in-convex-polygon-p (x y polygon)
+  "T if (x,y) is inside the convex POLYGON (ordered list of (x . y) vertices)."
+  (let ((n (length polygon)) (sign 0))
+    (dotimes (i n t)
+      (destructuring-bind (x1 . y1) (nth i polygon)
+	(destructuring-bind (x2 . y2) (nth (mod (1+ i) n) polygon)
+	  (let ((cross (- (* (- x2 x1) (- y y1)) (* (- y2 y1) (- x x1)))))
+	    (cond ((> cross 0) (if (minusp sign) (return nil) (setf sign 1)))
+		  ((< cross 0) (if (plusp sign)  (return nil) (setf sign -1))))))))))
+
+(defun site-in-domain-p (latitude longitude)
+  "Is a site inside the model's actual data coverage? hrdps_west uses the real tilted
+   1km footprint (so we never tile a box with no grid points); other models use the
+   axis-aligned tiling box, which already covers all their sites."
+  (if (string= *model* "hrdps_west")
+      (point-in-convex-polygon-p longitude latitude *hrdps-west-footprint*)
+      (and (<= *lry* latitude *uly*) (<= *ulx* longitude *lrx*))))

--- a/continental-test/plot-generation/locations-group-by-id-and-run-windgrams.lisp
+++ b/continental-test/plot-generation/locations-group-by-id-and-run-windgrams.lisp
@@ -25,7 +25,7 @@
 		 ;; hrdps_west nest from emitting empty/broken windgrams for out-of-domain (e.g. eastern) sites.
 		 (let ((lonf (read-from-string lon)) (latf (read-from-string lat)))
 		   (when (and (or (not model) (string= model *model*))
-		              (<= *lry* lonf *uly*) (<= *ulx* latf *lrx*)) ;; lon var holds LAT, lat var holds LON in this file
+		              (site-in-domain-p lonf latf)) ;; lon var holds LAT, lat var holds LON in this file
 		     (push (list :label-lat-lon (format nil "~A,~A,~A" location lon lat) :index index) (gethash (tile-id lon lat) result-hash)))))))
     (with-open-file (out outputfilename :direction :output :if-exists :supersede)
       (iter (for (tile-id list-of-sites) in-hashtable result-hash)

--- a/continental-test/required-tile-iterator.lisp
+++ b/continental-test/required-tile-iterator.lisp
@@ -13,8 +13,15 @@
 	 (destructuring-bind (region location lon lat &optional model)
 	     (mapcar (lambda (x) (string-trim '(#\Space) x)) (cl-ppcre:split "," line))
 	   (declare (ignorable region model location))
-	   (when (or (not model) (string= model *model*))
-	     (pushnew (multiple-value-list (tile-id lon lat)) tile-ids :test #'equalp)))))
+	   ;; Only tile sites inside the model domain. No-op for the wide hrdps/gdps boxes;
+	   ;; stops the regional hrdps_west nest from making out-of-domain tile dirs, where
+	   ;; wgrib2 -small_grib has no grid points to clip and dumps the full grid (~200MB/hr,
+	   ;; which fills the disk). NB: this file's columns are region,location,LAT,LON, so the
+	   ;; var named `lon` holds latitude and `lat` holds longitude.
+	   (let ((lonf (read-from-string lon)) (latf (read-from-string lat)))
+	     (when (and (or (not model) (string= model *model*))
+	                (site-in-domain-p lonf latf))
+	       (pushnew (multiple-value-list (tile-id lon lat)) tile-ids :test #'equalp))))))
     tile-ids))
 
 (defun only-required-tile-iterator ()

--- a/continental-test/upload-map-pngs.sh
+++ b/continental-test/upload-map-pngs.sh
@@ -14,9 +14,12 @@ echo "Done making directories"
 cd $PNGDIR
 echo "Uploading files"
 echo "There are `ls -1 | wc | awk '{print $1}'` files in `pwd`"
-tar cf - * | ssh -i ~/.ssh/montreal.pem ubuntu@$WEBSERVERIP "(cd $BASEDIR; tar xf -)"
+# mkdir+cd in the SAME remote command as the extract: a separate earlier `mkdir -p $BASEDIR`
+# can be lost to a flaky ssh, and then a bare `cd $BASEDIR; tar` silently extracts into the
+# home directory. This bit a brand-new model (hrdps_west) whose dir did not yet exist.
+tar cf - * | ssh -i ~/.ssh/montreal.pem ubuntu@$WEBSERVERIP "(mkdir -p $BASEDIR && cd $BASEDIR && tar xf -)"
 echo "Done uploading files, updating latest link"
-ssh -i ~/.ssh/montreal.pem ubuntu@$WEBSERVERIP "(cd $BASEDIR; rm -f latest ; ln -s `ls -1rt | tail -1` latest )"
+ssh -i ~/.ssh/montreal.pem ubuntu@$WEBSERVERIP "(mkdir -p $BASEDIR && cd $BASEDIR && rm -f latest && ln -s `ls -1rt | tail -1` latest )"
 echo "Deleting old map-pngs again"
 ssh -i ~/.ssh/montreal.pem ubuntu@$WEBSERVERIP "(cd canadarasp ; ./delete-old-map-pngs.sh)"
 echo "Archiving old maps for BC"


### PR DESCRIPTION
Two problems Andrew found in production after the 1km model went live. The 1km
cron is currently disabled; this is the fix so it can be turned back on.

## 1. Windgram tiles filled the disk (~200MB per hour)

The tile list is built from locations.txt. It filtered sites by model but not by
location, so for the 1km nest it tried to cut tiles for sites all over Canada,
not just BC/Alberta.

The 1km data is a tilted rotated grid that only covers BC and western Alberta.
When a tile box falls entirely outside that data, wgrib2 -small_grib has no grid
points to clip and returns the whole grid unchanged (the full 1330x1180, ~200MB)
instead of a small slice. That is the 212MB tile Andrew saw in
.../-140:-138:64:66, which is up in the Yukon/Alaska corner, outside the data.

In the first PR I added a domain filter to the windgram-rendering path but missed
this second site list (find-all-tile-ids), which is the one that actually cuts
the tiles.

Fix: one shared check, site-in-domain-p, used by both site lists. For hrdps_west
it tests the real tilted footprint (a 4-corner polygon from un-rotating the grid),
because the axis-aligned box corners stick out past the data and a tight axis box
would drop Vancouver. Other models keep their existing wide box, so nothing
changes for hrdps/gdps.

Checked in the docker stack:

| | before | after |
|--|--|--|
| tiles generated | 44 | 31 (out-of-footprint corners gone, BC kept) |
| biggest tile / hour | 220 MB | 9 MB |
| total / hour | 2.2 GB | ~220 MB |

## 2. Map PNGs uploaded to the home directory on the web server

upload-map-pngs.sh makes the destination directory in one ssh call, then extracts
the tarball in a separate call with `cd $BASEDIR; tar xf -`. If the first ssh
hiccups (the script itself notes the connection is unreliable), the directory is
missing, `cd` fails, and tar quietly extracts into the home directory. An existing
model already has its directory from earlier runs, so it never hits this. A
brand-new model like hrdps_west does.

Fix: mkdir and cd in the same command as the extract, so it can't fall back to
home. Same for the `latest` symlink line. This helps every model, not just 1km.

## Notes

- I could not reproduce #2 directly: the upload path talks to the real web server
  and is stubbed out in the docker stack, so this is a careful read of the script,
  not a repro. The change is strictly safer regardless.
- The 1km cron lines are still commented out. Worth re-enabling once this is
  deployed and one run looks clean on disk.
