### PR TITLE
Fix 1h time shift on all HRDPS windgrams

### DIFF
--- a/continental-test/plot-generation/windgram-continental.ncl
+++ b/continental-test/plot-generation/windgram-continental.ncl
@@ -209,6 +209,11 @@ begin
    end if
    date_str = TZ_str + " date "+quote+"+%a %d %b %Y %H:%M %Z" + quote+" -d " + quote + yyyy_mm_dd + " +" + tostring(stringtoint(run_time)) + "hours UTC" + quote
    local_start_time = systemfunc(date_str)
+   ;; local_start_time anchors the day-window math at the model init hour, but the
+   ;; first data file can be a later forecast hour (taus(0), e.g. P001 when the feed
+   ;; has no hour 0), so the displayed "First hour" is computed separately.
+   first_data_str = TZ_str + " date "+quote+"+%a %d %b %Y %H:%M %Z" + quote+" -d " + quote + yyyy_mm_dd + " +" + (stringtoint(run_time)+taus(0)) + "hours UTC" + quote
+   local_first_data_time = systemfunc(first_data_str)
    print ("Using model initialized on date " + yyyy_mm_dd + " at " + run_time + ":00 UTC")
    print("Local start time of the model is " + local_start_time)
    startHour = stringtoint(systemfunc(TZ_str + " date +%H -d "+quote+local_start_time +quote))
@@ -472,7 +477,7 @@ begin
       tstride=tstridemultiday ;; 2
       toffset=toffsetmultiday ;; 1
 
-      MainTitle = model_label + " Windgram for "+ site_name + ", First hour is " + local_start_time
+      MainTitle = model_label + " Windgram for "+ site_name + ", First hour is " + local_first_data_time
       lstDayColor = "gold"
       barbLen = 0.023
       ; smooth the LCL and HCRIT results

--- a/continental-test/plot-generation/windgram-hrdps.ncl
+++ b/continental-test/plot-generation/windgram-hrdps.ncl
@@ -8,8 +8,16 @@ tstridemultiday=2
 toffsetmultiday=1
 function hour_to_idx (hour, roundup)
 begin
- return hour
- ;; return(ind(taus.eq.hour))
+ ;; taus are contiguous hourly forecast hours starting at taus(0), which is not
+ ;; necessarily 0 (the current HRDPS feeds start at P001), so index = hour - taus(0).
+ idx = hour - taus(0)
+ if (idx .lt. 0) then
+   idx = 0
+ end if
+ if (idx .gt. numtimes - 1) then
+   idx = numtimes - 1
+ end if
+ return idx
 end
 
 function ij_from_lat_lon_generic (a, site_lat, site_lon)
@@ -51,7 +59,22 @@ begin
       ;; WHAT TIMES ARE AVAILABLE?
    numtimes=dimsizes(timesinfiles)
    print("numtimes " + numtimes)
-   taus:=ispan(0,numtimes-1,1)   ;coordinate variable for Time dimension
+   ;; The first file is not necessarily forecast hour 0: since the rotated-grid
+   ;; switch the HRDPS feeds have no precip rate at hour 0 (TIMESTART=1 in
+   ;; model-parameters.sh), so the file list starts at P001. Read the true first
+   ;; forecast hour from the GRIB metadata; assuming 0 here labelled every HRDPS
+   ;; windgram time one hour early. Units differ per feed: the continental 2.5km
+   ;; files say "60 minutes" where the 1km-west files say "1 hours".
+   tau0 = 0
+   if (isatt(ter, "forecast_time") .and. isatt(ter, "forecast_time_units")) then
+     if (ter@forecast_time_units .eq. "hours") then
+       tau0 = ter@forecast_time
+     end if
+     if (ter@forecast_time_units .eq. "minutes") then
+       tau0 = ter@forecast_time / 60
+     end if
+   end if
+   taus := tau0 + ispan(0,numtimes-1,1)   ;coordinate variable for Time dimension: true forecast hours
 
    initialization_date = str_get_field(ter@initial_time,1," ");
    run_str = str_get_field(ter@initial_time,2," ");


### PR DESCRIPTION
Was trying to figure out why the new 1km windgrams only went to 4pm and went down an immense rabbit hole where it looks like times have been off by an hour for years. 

## The bug

Since the rotated-grid switch (Dec 2022) the HRDPS feeds have no hour-0 file ("no prate data for zero", so TIMESTART=1) and the tile files start at P001. But windgram-hrdps.ncl still builds the time axis as `ispan(0, numtimes-1, 1)`, which labels the first file as the init hour. So every time on every HRDPS windgram (2.5km and 1km, static and dynamic) has been drawn one hour earlier than the data's actual valid time, for about 3.5 years. The 7am-9pm day windows were actually selecting 8am-10pm data, which means thermal start/end times have been reading an hour early.

The 4pm thing falls out of this: the 00Z west run really does end at 5pm PDT the next day (it's a 48h model), but the shift displayed that last hour as 4pm.

## The fix

Read the first file's actual forecast hour from the GRIB metadata and offset taus by it. Watch out: the two feeds encode this differently. The continental 2.5km files say "60 minutes" while the 1km west files say "1 hours". Both are handled; anything unrecognized falls back to the old behaviour.

hour_to_idx was just `return hour`, assuming hour == file index. It is now `hour - taus(0)` with clamping. The "First hour is ..." title now shows the first data hour instead of the init hour. The day-window math stays anchored at the init hour, so it comes out right on its own.

GDPS is untouched, its files start at P000 and windgram-gdps.ncl already did a real lookup.

## Checked in the docker stack

Pulled the full 48-file runs for one Vancouver-area tile of each model straight from the live server and rendered them with the docker NCL, using wgrib2 valid times as ground truth:

| check | before | after | ground truth (wgrib2) |
|--|--|--|--|
| west 00Z run, first hour in title | 17:00 PDT | 18:00 PDT | P001 vt=2026061101 = 18:00 PDT |
| west 00Z run, last column | 4pm | 5pm | P048 vt=2026061300 = 17:00 PDT |
| west one-day window (7am-9pm) | indices 14-28 (8am-10pm data) | indices 13-27 (7am-9pm data) | P014 = 14Z = 7am PDT |
| 2.5km 06Z run, first hour | 23:00 PDT | 00:00 PDT | P001 = 07Z = 00:00 PDT |
| 2.5km day-0 window | indices 8-22 | indices 7-21 (P008-P022) | P008 = 14Z = 7am PDT |

The 2.5km render also exercises the minutes-units path, which would have been off by 60 hours if handled naively.

Cached dynamic PNGs keep their old labels until the next model run supersedes them, and the static PNGs regenerate on the next cron cycle, so this rolls out on its own after merge.