### PR TITLE
Fix HRDPS windgram wind direction on rotated_ll grids.

### DIFF
--- a/continental-test/plot-generation/windgram-hrdps.ncl
+++ b/continental-test/plot-generation/windgram-hrdps.ncl
@@ -26,6 +26,31 @@ begin
  return(/blarg(0,0), blarg(0,1)/)
 end
 
+;; HRDPS U/V are grid-relative (along model i/j, not true E/N).  NCL gridrot_0 is
+;; for polar-stereographic / Lambert grids and gives wrong angles on MSC rotated_ll.
+;; Compute the local grid-tilt angle from gridlat_0/gridlon_0 instead (same method
+;; as map-wind GDAL reprojection and MSC uvRelativeToGrid handling).
+function grid_tilt_radians (a, locY, locX)
+local lat2d, lon2d, nx, dlat, dlon, latr
+begin
+  lat2d = a[0]->gridlat_0
+  lon2d = a[0]->gridlon_0
+  nx = dimsizes(lon2d,1)
+  if (locX.le.0 .or. locX.ge.nx-1) then
+    return 0.
+  end if
+  dlat = 0.5*(lat2d(locY,locX+1) - lat2d(locY,locX-1))
+  dlon = lon2d(locY,locX+1) - lon2d(locY,locX-1)
+  if (dlon.gt.180.) then
+    dlon = dlon - 360.
+  end if
+  if (dlon.lt.-180.) then
+    dlon = dlon + 360.
+  end if
+  latr = lat2d(locY,locX)*0.0174532925
+  return atan2(dlat, dlon*cos(latr))
+end
+
 ;TMP_P0_L100_GST0 TMP_P0_L100_GRLL0
 ;TMP_P0_L103_GRLL0
 ;DEPR_P0_L100_GRLL0
@@ -87,7 +112,7 @@ end
 procedure load_variables_one_point (a, locY, locX)
 local lasthour, windUr, windVr, windUrSfc, windVrSfc, numlevels
 begin
-    radian_rot=0 ; you would think we need to apply this, but no... a[0]->gridrot_0(locY,locX)
+    radian_rot = grid_tilt_radians(a, locY, locX)
     ListSetType(a,"cat")
     lasthour = ListCount(a)-1
     print("Last hour index is " + lasthour)


### PR DESCRIPTION
- Fix HRDPS windgram wind direction on MSC `rotated_ll` grids (2.5 km continental and 1 km west).
- Replace hardcoded `radian_rot=0` with a local grid-tilt angle computed from `gridlat_0` / `gridlon_0` finite differences at each site.
- Avoid NCL `gridrot_0`, which is for polar-stereographic / Lambert grids and gives wrong angles on HRDPS (fixes eastern Canada but breaks BC when enabled).

Map-wind arrows already account for grid tilt via GDAL reprojection (`anglepixelref` in `generate-single-hrdps-plot-continental.lisp`); windgrams were still using raw grid-relative U/V.

